### PR TITLE
Fix encoding when writing source files for search.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 setup(
     name='sphinx-markdown',
-    version='1.0.0',
+    version='1.0.1',
     description='Sphinx extension to support Markdown files',
     url='https://github.com/Alphadelta14/sphinx-markdown',
     author='Alphadelta14',

--- a/sphinx_markdown/search.py
+++ b/sphinx_markdown/search.py
@@ -43,5 +43,6 @@ def handle_page_context_html(app, pagename_, templatename_, context, doctree):
     nodetext = re.sub(r'(?is)<script.*?</script>', '', nodetext)
     nodetext = re.sub(r'<[^<]+?>', '', nodetext)
     nodetext = re.sub(r'&[^ ;]+?;', '', nodetext)
+    encoding = context.get('encoding', 'utf-8')
     with open(outname, 'w') as writer:
-        writer.write(nodetext.encode('ascii', 'ignore'))
+        writer.write(nodetext.encode(encoding, 'ignore'))


### PR DESCRIPTION
Use context['encoding'] and fallback to utf-8 if it is not set.

This will fix issues for languages that are different from English.