### PR TITLE
Fix for deprecated sphinx.util.compat.Directive class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 setup(
     name='sphinx-markdown',
-    version='1.0.1',
+    version='1.0.2',
     description='Sphinx extension to support Markdown files',
     url='https://github.com/Alphadelta14/sphinx-markdown',
     author='Alphadelta14',

--- a/sphinx_markdown/directives.py
+++ b/sphinx_markdown/directives.py
@@ -1,10 +1,7 @@
 
 from docutils.parsers.rst import directives
 from sphinx.ext.autodoc import Options
-try:
-    from sphinx.util.compat import Directive
-except ImportError:
-    from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive
 
 from sphinx_markdown.nodes import MarkdownNode
 

--- a/sphinx_markdown/directives.py
+++ b/sphinx_markdown/directives.py
@@ -1,7 +1,10 @@
 
 from docutils.parsers.rst import directives
 from sphinx.ext.autodoc import Options
-from sphinx.util.compat import Directive
+try:
+    from sphinx.util.compat import Directive
+except ImportError:
+    from docutils.parsers.rst import Directive
 
 from sphinx_markdown.nodes import MarkdownNode
 


### PR DESCRIPTION
The class is deprecated since sphinx version 1.6